### PR TITLE
speed up summary 💨

### DIFF
--- a/proxy/services/ai/conversations.py
+++ b/proxy/services/ai/conversations.py
@@ -334,7 +334,12 @@ async def _format_conversation(
                     elif item.get("type") == "image_url" and isinstance(
                         message, HumanMessage
                     ):
-                        content += f"{await execute_vision([message], session, agent_settings)}\n"
+                        if operation == "summary":
+                            # Use placeholder for summary operation
+                            content += "[image]\n"
+                        else:
+                            # Use vision conversion for condense operation
+                            content += f"{await execute_vision([message], session, agent_settings)}\n"
             return f"{prefix}{content.replace('\n', ' ')}" if content else ""
         else:
             return f"{prefix}{message.content.replace('\n', ' ')}"

--- a/proxy/services/ai/conversations.py
+++ b/proxy/services/ai/conversations.py
@@ -311,7 +311,7 @@ async def _format_conversation(
 ) -> List[str]:
     """
     Asynchronously formats a conversation into a list of speaker-prefixed strings.
-    
+
     Depending on the operation, formats each message with appropriate speaker labels and handles messages containing images by either inserting a placeholder or invoking a vision model to convert images to text.
     """
     if not conversation:
@@ -322,7 +322,7 @@ async def _format_conversation(
     ) -> str:
         """
         Formats a single conversation message as a string with appropriate speaker prefix.
-        
+
         For messages containing multiple content items, text is included directly. Image URLs are replaced with a placeholder for summary operations or converted to text using a vision model for condense operations.
         """
         first_person = "A" if operation == "condense" else "User"


### PR DESCRIPTION
# Optimize Thread Summary Generation with Image Placeholders

## Description
This PR optimizes the thread summary generation process by replacing image-to-text conversions with simple placeholders during summary generation. This change significantly improves performance and prevents timeouts in the `/close` endpoint when processing threads with multiple images.

## Changes
- Modified `_format_conversation` in `proxy/services/ai/conversations.py` to handle images differently based on operation type:
  - Uses `[image]` placeholder for summary operations
  - Maintains existing vision conversion for condense operations

## Why
Currently, when generating a summary for a thread (during the `/close` endpoint), images in the conversation are converted to text descriptions using vision models. This process is time-consuming, especially when there are multiple images, and can lead to timeouts in the `/close` endpoint.

## Impact
- **Performance**: Significantly faster summary generation for threads with images
- **Reliability**: Prevents timeouts in the `/close` endpoint
- **Context**: Maintains conversation context by indicating image presence
- **Behavior**: No changes to the main conversation flow or condense operations

## Testing
The changes have been tested with:
- Threads containing multiple images
- Mixed content (text and images)
- Text-only conversations
- Various image types and sizes

## Related Issues
Closes #62 

## Notes
- The change is backward compatible
- No modifications to other parts of the codebase were required
- The behavior for non-summary operations remains unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of image messages in conversation summaries by displaying a placeholder instead of processing images, resulting in faster and more consistent summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->