### PR TITLE
Expire previous runs before creating a new run in ThreadManager 

### DIFF
--- a/proxy/services/thread_manager.py
+++ b/proxy/services/thread_manager.py
@@ -286,6 +286,9 @@ class ThreadManager:
                 created_at=datetime.now(),
                 updated_at=datetime.now(),
             )
+            # First, expire previous runs for this thread
+            await self.db.expire_runs(thread_id, organization_id)
+            # Then, create the new run
             run_id = await self.db.create_run(run)
             run_response = RunResponse(
                 agent_version=run_request.agent_version,


### PR DESCRIPTION
Expire previous runs before creating a new run in `ThreadManager` to ensure accurate run management.

Solves #77 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that previous runs are properly expired before starting a new run in a thread, improving the accuracy and reliability of run status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->