### PR TITLE
Add API key header

### DIFF
--- a/proxy/auth/middleware.py
+++ b/proxy/auth/middleware.py
@@ -14,9 +14,17 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         if request.url.path == "/health":
             return await call_next(request)
 
+        # Get API key from various sources
         api_key = request.headers.get("X-API-Key") or request.query_params.get(
             "api_key"
         )
+
+        # Handle Authorization header with Bearer token
+        auth_header = request.headers.get("Authorization")
+        if auth_header and auth_header.startswith("Bearer "):
+            api_key = auth_header.replace("Bearer ", "")
+        elif auth_header:
+            api_key = auth_header
 
         if not api_key:
             return JSONResponse(

--- a/proxy/auth/middleware.py
+++ b/proxy/auth/middleware.py
@@ -14,17 +14,12 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         if request.url.path == "/health":
             return await call_next(request)
 
-        # Get API key from various sources
-        api_key = request.headers.get("X-API-Key") or request.query_params.get(
-            "api_key"
-        )
-
-        # Handle Authorization header with Bearer token
+        api_key = request.headers.get("X-API-Key")
+        if not api_key:
+            api_key = request.query_params.get("api_key")
         auth_header = request.headers.get("Authorization")
-        if auth_header and auth_header.startswith("Bearer "):
-            api_key = auth_header.replace("Bearer ", "")
-        elif auth_header:
-            api_key = auth_header
+        if not api_key and auth_header and auth_header.startswith("Bearer "):
+            api_key = auth_header[len("Bearer ") :]
 
         if not api_key:
             return JSONResponse(


### PR DESCRIPTION
Add API key extraction from Authorization header in middleware

Enhance the APIKeyMiddleware to support API key retrieval from the Authorization header using Bearer tokens. This allows for more flexible authentication methods while maintaining existing functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded API key support to accept keys from the "Authorization" header when using "Bearer" tokens, in addition to existing header and query parameter options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->